### PR TITLE
Set ldflags to optimize the size of released binaries

### DIFF
--- a/scripts/macos-build.sh
+++ b/scripts/macos-build.sh
@@ -2,10 +2,10 @@
 
 set -xeu
 
-LD_RUN_PATH=\$ORIGIN CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -v -buildmode=c-shared -o output/libasherah-arm64.dylib
+LD_RUN_PATH=\$ORIGIN CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -v -buildmode=c-shared -ldflags='-s -w' -o output/libasherah-arm64.dylib
 mv output/libasherah-arm64.h output/libasherah-darwin-arm64.h
 
-LD_RUN_PATH=\$ORIGIN CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -buildmode=c-shared -o output/libasherah-x64.dylib
+LD_RUN_PATH=\$ORIGIN CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -buildmode=c-shared -ldflags='-s -w' -o output/libasherah-x64.dylib
 mv output/libasherah-x64.h output/libasherah-darwin-x64.h
 
 go test -v -failfast -coverprofile cover.out

--- a/scripts/ubuntu-build-arm64.sh
+++ b/scripts/ubuntu-build-arm64.sh
@@ -4,6 +4,6 @@ set -xeu
 
 apt-get install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu -y
 
-LD_RUN_PATH=\$ORIGIN CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -v -buildmode=c-shared -o output/libasherah-arm64.so
+LD_RUN_PATH=\$ORIGIN CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -v -buildmode=c-shared -ldflags='-s -w' -o output/libasherah-arm64.so
 
 find output/ -print0 | xargs -0 file

--- a/scripts/ubuntu-build-x64.sh
+++ b/scripts/ubuntu-build-x64.sh
@@ -2,7 +2,7 @@
 
 set -xeu
 
-LD_RUN_PATH=\$ORIGIN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -v -buildmode=c-shared -o output/libasherah-x64.so
+LD_RUN_PATH=\$ORIGIN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -v -buildmode=c-shared -ldflags='-s -w' -o output/libasherah-x64.so
 
 go test -v -failfast -coverprofile cover.out
 


### PR DESCRIPTION
```
-s
	Omit the symbol table and debug information.
-w
	Omit the DWARF symbol table.
```

Reference: https://pkg.go.dev/cmd/link