### PR TITLE
Expose SetEnv API for setting environment variables

### DIFF
--- a/libasherah.go
+++ b/libasherah.go
@@ -70,7 +70,6 @@ func SetupJson(configJson unsafe.Pointer) int32 {
 	output.EnableVerboseOutput(options.Verbose)
 
 	output.VerboseOutput("Successfully deserialized config JSON")
-	output.VerboseOutput(options)
 
 	EstimatedIntermediateKeyOverhead = len(options.ProductID) + len(options.ServiceName)
 

--- a/libasherah_test.go
+++ b/libasherah_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/godaddy/cobhan-go"
 )
 
-func setupAsherahForTesting(t *testing.T, verbose bool) {
+var Verbose = true
+
+func setupAsherahForTesting(t *testing.T) {
 	config := &asherah.Options{}
 
 	config.KMS = "static"
@@ -22,7 +24,7 @@ func setupAsherahForTesting(t *testing.T, verbose bool) {
 	config.SessionCacheMaxSize = 2
 	config.ExpireAfter = 1000
 	config.CheckInterval = 1000
-	config.Verbose = verbose
+	config.Verbose = Verbose
 	config.RegionMap = asherah.RegionMap{}
 	config.RegionMap["region1"] = "arn1"
 	config.RegionMap["region2"] = "arn2"
@@ -60,7 +62,7 @@ func testAllocateJsonBuffer(t *testing.T, obj interface{}) []byte {
 }
 
 func TestSetupJson(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	Shutdown()
 }
 
@@ -72,7 +74,7 @@ func TestSetupJsonAlternateConfiguration(t *testing.T) {
 	config.ProductID = "TestProduct"
 	config.Metastore = "memory"
 	config.EnableSessionCaching = true
-	config.Verbose = false
+	config.Verbose = Verbose
 
 	buf := testAllocateJsonBuffer(t, config)
 
@@ -91,7 +93,7 @@ func TestSetupJsonTwice(t *testing.T) {
 	config.ProductID = "TestProduct"
 	config.Metastore = "memory"
 	config.EnableSessionCaching = true
-	config.Verbose = true
+	config.Verbose = Verbose
 
 	buf := testAllocateJsonBuffer(t, config)
 
@@ -119,7 +121,7 @@ func TestSetupInvalidJson(t *testing.T) {
 }
 
 func TestSetEnv(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	env := Env{}
 	env["VAR1"] = "VALUE1"
 	env["VAR2"] = "VALUE2"
@@ -161,7 +163,7 @@ func TestSetupNullJson(t *testing.T) {
 }
 
 func TestEncryptDecryptRoundTrip(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	input := "InputData"
@@ -263,7 +265,7 @@ func TestDecryptWithoutInit(t *testing.T) {
 }
 
 func TestEncryptNullPartitionId(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	data := testAllocateStringBuffer(t, "InputData")
@@ -288,7 +290,7 @@ func TestEncryptNullPartitionId(t *testing.T) {
 }
 
 func TestEncryptNullData(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	partitionId := testAllocateStringBuffer(t, "Partition")
@@ -312,7 +314,7 @@ func TestEncryptNullData(t *testing.T) {
 }
 
 func TestEncryptNullEncryptedData(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	partitionId := testAllocateStringBuffer(t, "Partition")
@@ -336,7 +338,7 @@ func TestEncryptNullEncryptedData(t *testing.T) {
 }
 
 func TestEncryptNullEncryptedKey(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	partitionId := testAllocateStringBuffer(t, "Partition")
@@ -360,7 +362,7 @@ func TestEncryptNullEncryptedKey(t *testing.T) {
 }
 
 func TestEncryptNullCreatedBuf(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	partitionId := testAllocateStringBuffer(t, "Partition")
@@ -384,7 +386,7 @@ func TestEncryptNullCreatedBuf(t *testing.T) {
 }
 
 func TestEncryptNullParentKeyId(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	partitionId := testAllocateStringBuffer(t, "Partition")
@@ -408,7 +410,7 @@ func TestEncryptNullParentKeyId(t *testing.T) {
 }
 
 func TestEncryptNullParentKeyCreated(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	partitionId := testAllocateStringBuffer(t, "Partition")
@@ -432,7 +434,7 @@ func TestEncryptNullParentKeyCreated(t *testing.T) {
 }
 
 func TestDecryptNullPartitionId(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	input := "InputData"
@@ -482,7 +484,7 @@ func TestDecryptNullPartitionId(t *testing.T) {
 }
 
 func TestDecryptNullEncryptedData(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	input := "InputData"
@@ -532,7 +534,7 @@ func TestDecryptNullEncryptedData(t *testing.T) {
 }
 
 func TestDecryptNullEncryptedKey(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	input := "InputData"
@@ -582,7 +584,7 @@ func TestDecryptNullEncryptedKey(t *testing.T) {
 }
 
 func TestDecryptNullParentKeyId(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	input := "InputData"
@@ -632,7 +634,7 @@ func TestDecryptNullParentKeyId(t *testing.T) {
 }
 
 func TestDecryptNullDecryptedData(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	input := "InputData"
@@ -680,7 +682,7 @@ func TestDecryptNullDecryptedData(t *testing.T) {
 }
 
 func TestDecryptBadData(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	input := "InputData"
@@ -736,7 +738,7 @@ func TestDecryptBadData(t *testing.T) {
 }
 
 func TestEncryptToJsonAndDecryptFromJsonCycle(t *testing.T) {
-	setupAsherahForTesting(t, true)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	cycleEncryptToJsonAndDecryptFromJson("1", "1", t)
@@ -744,7 +746,7 @@ func TestEncryptToJsonAndDecryptFromJsonCycle(t *testing.T) {
 }
 
 func TestEncryptToJsonAndDecryptFromJsonCycleLong(t *testing.T) {
-	setupAsherahForTesting(t, false)
+	setupAsherahForTesting(t)
 	defer Shutdown()
 
 	longString := strings.Repeat("X", 16384)

--- a/libasherah_test.go
+++ b/libasherah_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -113,6 +114,43 @@ func TestSetupInvalidJson(t *testing.T) {
 	result := SetupJson(cobhan.Ptr(&buf))
 	if result != cobhan.ERR_JSON_DECODE_FAILED {
 		t.Errorf("Expected SetupJson to return ERR_JSON_DECODE_FAILED got %v", result)
+	}
+	Shutdown()
+}
+
+func TestSetEnv(t *testing.T) {
+	setupAsherahForTesting(t, true)
+	env := Env{}
+	env["VAR1"] = "VALUE1"
+	env["VAR2"] = "VALUE2"
+
+	buf := testAllocateJsonBuffer(t, env)
+
+	result := SetEnv(cobhan.Ptr(&buf))
+	if result != cobhan.ERR_NONE {
+		t.Errorf("SetEnv returned %v", result)
+	}
+
+	var1 := os.Getenv("VAR1")
+	if var1 != "VALUE1" {
+		t.Errorf("Failed to set VAR1 env var")
+	}
+
+	var2 := os.Getenv("VAR2")
+	if var2 != "VALUE2" {
+		t.Errorf("Failed to set VAR2 env var")
+	}
+	Shutdown()
+}
+
+func TestSetupInvalidEnv(t *testing.T) {
+	str := "}InvalidEnv{"
+
+	buf := testAllocateStringBuffer(t, str)
+
+	result := SetEnv(cobhan.Ptr(&buf))
+	if result != cobhan.ERR_JSON_DECODE_FAILED {
+		t.Errorf("Expected SetEnv to return ERR_JSON_DECODE_FAILED got %v", result)
 	}
 	Shutdown()
 }


### PR DESCRIPTION
When running Asherah inside Fargate container on AWS, sometimes we get `decrypt failed in all regions`. It turns out it is because the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` ENV variable isn't properly passed from Ruby (C) to Go (CGO), and the actual error within `aws-sdk-go` inside Asherah is `NoCredentialProviders: no valid providers in chain.`.

I've tried to load Asherah in different ways inside a Rails application and have come to a point where the error happens intermittently, though it's not entirely resolved. I think it is triggered when we set some other ENV variables inside Ruby, and the CGO ENV somehow gets messed up.

Most likely, it is related to https://github.com/golang/go/issues/44108, and there is also a note in the [wiki section](https://github.com/golang/go/wiki/cgo#environmental-variables) for environment variables that `Go os.Getenv() doesn't see variables set by C.setenv()`.

By exposing the `SetEnv` API, we can now work around this issue and provide the environment variables that Asherah needs to set for its dependency (specifically `aws-sdk-go`).

Also removing the `options` print since it logs sensitive data like DB credentials.