### PR TITLE
Upgrade go version to 1.19

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:bullseye
+      image: golang:1.19.0-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19.0
     - name: Build for MacOS
       run: scripts/macos-build.sh
     - name: Publish MacOS sha256sums

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:bullseye
+      image: golang:1.19.0-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -29,6 +29,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19.0
     - name: Build for MacOS
       run: scripts/macos-build.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/godaddy/asherah-cobhan
 
-go 1.18
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.43.20


### PR DESCRIPTION
Last binaries build was with Go version `1.18.4` that has the following CVE:
```
{
  "CVE": "CVE-2022-32189",
  "CVSS": "7.50",
  "Fixed On": "10 Aug 22 20:15 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-32189",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.18.4",
  "Severity": "high",
  "Status": "fixed in 1.18.5, 1.17.13"
}
```