### PR TITLE
Upgrade go build version to 1.19.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.19-bullseye
+      image: golang:1.19.1-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: 1.19.1
     - name: Build for MacOS
       run: scripts/macos-build.sh
     - name: Publish MacOS sha256sums

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.19-bullseye
+      image: golang:1.19.1-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -29,6 +29,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: 1.19.1
     - name: Build for MacOS
       run: scripts/macos-build.sh

--- a/scripts/ubuntu-configure.sh
+++ b/scripts/ubuntu-configure.sh
@@ -4,11 +4,12 @@ set -xeu
 # Optionally use a different mirror if azure.archive.ubuntu.com is being lame
 #sed -i 's/azure.archive.ubuntu.com/mirror.arizona.edu/g' /etc/apt/sources.list
 apt-get update -y
-apt-get install software-properties-common -y
+apt-get install software-properties-common curl -y
 
-apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-#echo "deb https://cli.github.com/packages bullseye main" >> /etc/apt/sources.list
-apt-add-repository https://cli.github.com/packages
+# https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+&& chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 
 apt-get update -y
 


### PR DESCRIPTION
Last binaries were built with Go version `1.19.0` that has the following CVE. We need to upgrade to 1.19.1 to fix it.
```json
{
  "CVE": "CVE-2022-27664",
  "CVSS": "7.50",
  "Fixed On": "06 Sep 22 18:15 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-27664",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.19",
  "Severity": "high",
  "Status": "fixed in 1.19.1, 1.18.6"
}
```