### PR TITLE
Upgrade go build version to 1.19.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.19.1-bullseye
+      image: golang:1.19.2-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19.1
+        go-version: 1.19.2
     - name: Build for MacOS
       run: scripts/macos-build.sh
     - name: Publish MacOS sha256sums

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.19.1-bullseye
+      image: golang:1.19.2-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -29,6 +29,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19.1
+        go-version: 1.19.2
     - name: Build for MacOS
       run: scripts/macos-build.sh


### PR DESCRIPTION
Upgrade Go build version to 1.19.2 to fix the following CVEs:

```json
{
  "CVE": "CVE-2022-2879",
  "CVSS": "7.50",
  "Fixed On": "14 Oct 22 15:15 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-2879",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.19.1",
  "Severity": "high",
  "Status": "fixed in 1.19.2, 1.18.7"
},
{
  "CVE": "CVE-2022-2880",
  "CVSS": "7.50",
  "Fixed On": "14 Oct 22 15:15 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-2880",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.19.1",
  "Severity": "high",
  "Status": "fixed in 1.19.2, 1.18.7"
},
{
  "CVE": "CVE-2022-41715",
  "CVSS": "7.50",
  "Fixed On": "14 Oct 22 15:16 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41715",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.19.1",
  "Severity": "high",
  "Status": "fixed in 1.19.2, 1.18.7"
}
```