### PR TITLE
Upgrade go version to 1.20 and go build version to 1.20.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.19.2-bullseye
+      image: golang:1.20.2-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19.2
+        go-version: 1.20.2
     - name: Build for MacOS
       run: scripts/macos-build.sh
     - name: Publish MacOS sha256sums

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
+    # Fix "fatal: detected dubious ownership in repository"
+    - name: Change owner of container working directory
+      run: chown root:root .
     - name: Configure packages
       run: scripts/ubuntu-configure.sh
     - name: Build for Linux x64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.19.2-bullseye
+      image: golang:1.20.2-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -29,6 +29,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19.2
+        go-version: 1.20.2
     - name: Build for MacOS
       run: scripts/macos-build.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/godaddy/asherah-cobhan
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.43.20


### PR DESCRIPTION
Upgrade go version to 1.20 and go build version to 1.20.2 to fix the following CVEs:
```
{
  "CVE": "CVE-2022-41723",
  "CVSS": "7.50",
  "Fixed On": "09 Mar 23 19:12 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41723",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.19.2",
  "Severity": "high",
  "Status": "fixed in 1.19.6"
},
{
  "CVE": "CVE-2022-41724",
  "CVSS": "7.50",
  "Fixed On": "10 Mar 23 07:13 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41724",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.19.2",
  "Severity": "high",
  "Status": "fixed in 1.19.6"
},
{
  "CVE": "CVE-2022-41725",
  "CVSS": "7.50",
  "Fixed On": "10 Mar 23 07:13 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41725",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.19.2",
  "Severity": "high",
  "Status": "fixed in 1.19.6"
}
```