### PR TITLE
Upgrade go version to 1.20.2 and go build version to 1.20.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.20.2-bullseye
+      image: golang:1.20.3-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.2
+        go-version: 1.20.3
     - name: Build for MacOS
       run: scripts/macos-build.sh
     - name: Publish MacOS sha256sums

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.20.2-bullseye
+      image: golang:1.20.3-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -32,6 +32,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.2
+        go-version: 1.20.3
     - name: Build for MacOS
       run: scripts/macos-build.sh

--- a/internal/asherah/asherah.go
+++ b/internal/asherah/asherah.go
@@ -76,7 +76,7 @@ func Encrypt(partitionId string, data []byte) (*appencryption.DataRowRecord, err
 	if globalInitialized == 0 {
 		return nil, ErrAsherahNotInitialized
 	}
-		
+
 	session, err := globalSessionFactory.GetSession(partitionId)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Upgrade go version to 1.20.3 to fix the following CVEs:

```
{
  "CVE": "CVE-2023-24538",
  "CVSS": "9.80",
  "Fixed On": "17 Apr 23 20:33 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-24538",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.2",
  "Severity": "critical",
  "Status": "fixed in 1.20.3, 1.19.8"
},
{
  "CVE": "CVE-2023-24534",
  "CVSS": "7.50",
  "Fixed On": "18 Apr 23 21:34 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-24534",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.2",
  "Severity": "high",
  "Status": "fixed in 1.20.3, 1.19.8"
},
{
  "CVE": "CVE-2023-24536",
  "CVSS": "7.50",
  "Fixed On": "17 Apr 23 20:33 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-24536",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.2",
  "Severity": "high",
  "Status": "fixed in 1.20.3, 1.19.8"
},
{
  "CVE": "CVE-2023-24537",
  "CVSS": "7.50",
  "Fixed On": "13 Apr 23 20:42 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-24537",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.2",
  "Severity": "high",
  "Status": "fixed in 1.20.3, 1.19.8"
}
```