### PR TITLE
Upgrade go build version to 1.20.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.20.3-bullseye
+      image: golang:1.20.4-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.3
+        go-version: 1.20.4
     - name: Build for MacOS
       run: scripts/macos-build.sh
     - name: Publish MacOS sha256sums

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.20.3-bullseye
+      image: golang:1.20.4-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -32,6 +32,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.3
+        go-version: 1.20.4
     - name: Build for MacOS
       run: scripts/macos-build.sh


### PR DESCRIPTION
Upgrade go build version to 1.20.4 to fix the following CVEs:

```
{
  "CVE": "CVE-2023-24540",
  "CVSS": "9.80",
  "Fixed On": "22 May 23 22:14 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-24540",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.3",
  "Severity": "critical",
  "Status": "fixed in 1.20.4, 1.19.9"
},
{
  "CVE": "CVE-2023-24539",
  "CVSS": "7.30",
  "Fixed On": "22 May 23 22:14 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-24539",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.3",
  "Severity": "high",
  "Status": "fixed in 1.20.4, 1.19.9"
},
{
  "CVE": "CVE-2023-29400",
  "CVSS": "7.30",
  "Fixed On": "22 May 23 22:14 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-29400",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.3",
  "Severity": "high",
  "Status": "fixed in 1.20.4, 1.19.9"
}
```