### PR TITLE
Upgrade go build version to 1.20.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.20.4-bullseye
+      image: golang:1.20.5-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.4
+        go-version: 1.20.5
     - name: Build for MacOS
       run: scripts/macos-build.sh
     - name: Publish MacOS sha256sums

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.20.4-bullseye
+      image: golang:1.20.5-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -32,6 +32,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.4
+        go-version: 1.20.5
     - name: Build for MacOS
       run: scripts/macos-build.sh


### PR DESCRIPTION
Upgrade go build version to 1.20.5 to fix the following CVEs:

```
{
  "CVE": "CVE-2023-29402",
    "CVSS": "9.80",
    "Fixed On": "16 Jun 23 19:03 UTC",
    "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-29402",
    "Package Name": "go",
    "Package Type": "Binary",
    "Package Version": "1.20.4",
    "Severity": "critical",
    "Status": "fixed in 1.20.5, 1.19.10"
},
{
  "CVE": "CVE-2023-29404",
  "CVSS": "9.80",
  "Fixed On": "16 Jun 23 15:00 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-29404",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.4",
  "Severity": "critical",
  "Status": "fixed in 1.20.5, 1.19.10"
},
{
  "CVE": "CVE-2023-29405",
  "CVSS": "9.80",
  "Fixed On": "16 Jun 23 15:00 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-29405",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.4",
  "Severity": "critical",
  "Status": "fixed in 1.20.5, 1.19.10"
},
{
  "CVE": "CVE-2023-29403",
  "CVSS": "7.80",
  "Fixed On": "16 Jun 23 07:04 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-29403",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.4",
  "Severity": "high",
  "Status": "fixed in 1.20.5, 1.19.10"
}
```