### PR TITLE
Upgrade go build version to 1.20.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.20.5-bullseye
+      image: golang:1.20.7-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.5
+        go-version: 1.20.7
     - name: Build for MacOS
       run: scripts/macos-build.sh
     - name: Publish MacOS sha256sums

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.20.5-bullseye
+      image: golang:1.20.7-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -32,6 +32,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.5
+        go-version: 1.20.7
     - name: Build for MacOS
       run: scripts/macos-build.sh


### PR DESCRIPTION
> go1.20.6 (released 2023-07-11) includes a security fix to the net/http package, as well as bug fixes to the compiler, cgo, the cover tool, the go command, the runtime, and the crypto/ecdsa, go/build, go/printer, net/mail, and text/template packages. See the [Go 1.20.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.20.6+label%3ACherryPickApproved) on our issue tracker for details.

> go1.20.7 (released 2023-08-01) includes a security fix to the crypto/tls package, as well as bug fixes to the assembler and the compiler. See the [Go 1.20.7 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.20.7+label%3ACherryPickApproved) on our issue tracker for details.