### PR TITLE
Upgrade go build version to 1.20.12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.20.10-bullseye
+      image: golang:1.20.12-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.10
+        go-version: 1.20.12
     - name: Build for MacOS
       run: scripts/macos-build.sh
     - name: Publish MacOS sha256sums

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21.2-bullseye
+      image: golang:1.20.12-bullseye
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - uses: actions/checkout@v2
@@ -32,6 +32,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.21.2
+        go-version: 1.20.12
     - name: Build for MacOS
       run: scripts/macos-build.sh


### PR DESCRIPTION
> go1.20.11 (released 2023-11-07) includes security fixes to the path/filepath package, as well as bug fixes to the linker and the net/http package. See the Go 1.20.11 milestone on our issue tracker for details.

> go1.20.12 (released 2023-12-05) includes security fixes to the go command, and the net/http and path/filepath packages, as well as bug fixes to the compiler and the go command. See the Go 1.20.12 milestone on our issue tracker for details.

Also, making test workflow go version consistent with the publish workflow go version.

CVEs:
```
{
  "CVE": "CVE-2023-45283",
  "CVSS": "7.50",
  "Fixed On": "15 Dec 23 11:55 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-45283",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.10",
  "Severity": "high",
  "Status": "fixed in 1.21.4, 1.20.11"
},
{
  "CVE": "CVE-2023-45285",
  "CVSS": "7.50",
  "Fixed On": "12 Dec 23 19:40 UTC",
  "Link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-45285",
  "Package Name": "go",
  "Package Type": "Binary",
  "Package Version": "1.20.10",
  "Severity": "high",
  "Status": "fixed in 1.21.5, 1.20.12"
}
```