### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       image: golang:bookworm
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     # Fix "fatal: detected dubious ownership in repository"
     - name: Change owner of container working directory
       run: chown root:root .
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.24
+        go-version: '1.24.5'
         check-latest: 'true'
     - name: Build for MacOS
       run: scripts/macos-build.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       image: golang:bookworm
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     # Fix "fatal: detected dubious ownership in repository"
     - name: Change owner of container working directory
       run: chown root:root .
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.24
+        go-version: '1.24.5'
         check-latest: 'true'
     - name: Build for MacOS
       run: scripts/macos-build.sh


### PR DESCRIPTION
## Summary
Updates GitHub Actions to latest stable versions to address security advisories and ensure compatibility with current runtime.

## Changes
- CodeQL actions: v1 → v3 (latest stable, v2 is deprecated)
- Checkout actions: v2 → v4 (standardized across all workflows)
- Go version: 1.24 → 1.24.5 (use specific current version)

## Notes
- v3 is the current stable version of CodeQL actions
- actions/checkout@v4 is backward compatible
- Go 1.24.5 is the current Go release

## Test plan
- [x] Workflow syntax is valid
- [x] No breaking changes in action versions
- [x] Version updates are compatible with project requirements