### PR TITLE
Add Go warmup library for JavaScript runtime compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Publish Linux sha256sums
       run: scripts/generate-sha256.sh > output/SHA256SUMS
     - name: Upload Artifacts
-      run: scripts/upload-artifacts.sh output/libasherah-x64.h output/libasherah-x64.so output/libasherah-x64.a output/libasherah-x64-archive.h output/libasherah-arm64.h output/libasherah-arm64.so output/libasherah-arm64.a output/libasherah-arm64-archive.h output/SHA256SUMS
+      run: scripts/upload-artifacts.sh output/libasherah-x64.h output/libasherah-x64.so output/libasherah-x64.a output/libasherah-x64-archive.h output/libasherah-arm64.h output/libasherah-arm64.so output/libasherah-arm64.a output/libasherah-arm64-archive.h output/go-warmup-linux-x64.so output/go-warmup-linux-arm64.so output/SHA256SUMS
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-macos:
@@ -43,6 +43,6 @@ jobs:
     - name: Publish MacOS sha256sums
       run: scripts/generate-sha256.sh > output/SHA256SUMS-darwin
     - name: Upload Artifacts
-      run: scripts/upload-artifacts.sh output/libasherah-darwin-x64.h output/libasherah-x64.dylib output/libasherah-darwin-arm64.h output/libasherah-arm64.dylib output/libasherah-darwin-arm64.a output/libasherah-darwin-x64.a output/libasherah-darwin-x64-archive.h output/libasherah-darwin-arm64-archive.h output/SHA256SUMS-darwin
+      run: scripts/upload-artifacts.sh output/libasherah-darwin-x64.h output/libasherah-x64.dylib output/libasherah-darwin-arm64.h output/libasherah-arm64.dylib output/libasherah-darwin-arm64.a output/libasherah-darwin-x64.a output/libasherah-darwin-x64-archive.h output/libasherah-darwin-arm64-archive.h output/go-warmup-darwin-x64.dylib output/go-warmup-darwin-arm64.dylib output/SHA256SUMS-darwin
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/GO_WARMUP.md
+++ b/GO_WARMUP.md
@@ -1,0 +1,42 @@
+# Go Warmup Library
+
+## Purpose
+
+The `go_warmup` library provides a minimal Go shared library that can be loaded via FFI from JavaScript runtimes to initialize the Go runtime before loading CGO-based N-API modules. This prevents runtime errors that occur when crypto/x509 initialization runs in certain JavaScript runtime environments.
+
+## Background
+
+Some JavaScript runtimes (like Bun) don't properly initialize the Go runtime when loading CGO-based N-API modules, leading to crashes during crypto/x509 initialization. By loading this minimal warmup library first via FFI, we ensure the Go runtime is properly initialized before the main library loads.
+
+## Implementation
+
+The library exports a single function:
+- `Warmup() int` - Initializes Go runtime and returns 1
+
+## Build Artifacts
+
+Platform-specific libraries are built and included in releases:
+- **Linux x64**: `go-warmup-linux-x64.so`
+- **Linux ARM64**: `go-warmup-linux-arm64.so`
+- **Darwin x64**: `go-warmup-darwin-x64.dylib`
+- **Darwin ARM64**: `go-warmup-darwin-arm64.dylib`
+
+## Usage Example
+
+JavaScript runtimes can use this library to ensure Go runtime compatibility:
+
+```javascript
+// Detect runtime and load warmup library if needed
+if (typeof Bun !== 'undefined') {
+  const { dlopen, FFIType } = require('bun:ffi');
+  const lib = dlopen('path/to/go-warmup-platform.so', {
+    Warmup: { returns: FFIType.int, args: [] }
+  });
+  lib.symbols.Warmup();
+}
+// Now safe to load CGO-based N-API modules
+```
+
+## Testing
+
+The warmup library has been tested with asherah-node in the Bun runtime and confirmed to resolve compatibility issues, enabling full functionality of CGO-based N-API modules.

--- a/go_warmup.go
+++ b/go_warmup.go
@@ -1,0 +1,18 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import "C"
+
+// Warmup initializes the Go runtime for JavaScript runtime compatibility.
+// This function is called via FFI from JavaScript runtimes (like Bun) before 
+// loading CGO-based N-API modules. It prevents runtime errors that occur when 
+// crypto/x509 initialization runs in certain JavaScript runtime environments.
+//
+//export Warmup
+func Warmup() C.int {
+	return 1
+}
+
+func main() {}

--- a/scripts/macos-build.sh
+++ b/scripts/macos-build.sh
@@ -19,5 +19,13 @@ mv output/libasherah-x64.h output/libasherah-darwin-x64.h
 
 go test -v -failfast -coverprofile cover.out
 
+# Build Go warmup libraries for JavaScript runtime compatibility
+echo "Building Go warmup libraries..."
+CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -buildmode=c-shared -ldflags='-s -w' -o output/go-warmup-darwin-arm64.dylib -tags="" go_warmup.go
+rm -f output/go_warmup.h  # Remove unnecessary header file
+
+CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -buildmode=c-shared -ldflags='-s -w' -o output/go-warmup-darwin-x64.dylib -tags="" go_warmup.go
+rm -f output/go_warmup.h  # Remove unnecessary header file
+
 find output/ -print0 | xargs -0 file
 

--- a/scripts/ubuntu-build-arm64.sh
+++ b/scripts/ubuntu-build-arm64.sh
@@ -8,4 +8,9 @@ CGO_ENABLED=1 GOOS=linux GODEBUG=cgocheck=0 GOARCH=arm64 CC=aarch64-linux-gnu-gc
 mv output/libasherah-arm64.h output/libasherah-arm64-archive.h
 LD_RUN_PATH=\$ORIGIN CGO_ENABLED=1 GODEBUG=cgocheck=0 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -v -buildmode=c-shared -ldflags='-s -w' -o output/libasherah-arm64.so
 
+# Build Go warmup library for JavaScript runtime compatibility
+echo "Building Go warmup library for Linux ARM64..."
+CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -buildmode=c-shared -ldflags='-s -w' -o output/go-warmup-linux-arm64.so -tags="" go_warmup.go
+rm -f output/go_warmup.h  # Remove unnecessary header file
+
 find output/ -print0 | xargs -0 file

--- a/scripts/ubuntu-build-x64.sh
+++ b/scripts/ubuntu-build-x64.sh
@@ -8,5 +8,10 @@ LD_RUN_PATH=\$ORIGIN CGO_ENABLED=1 GOOS=linux GODEBUG=cgocheck=0 GOARCH=amd64 go
 
 go test -v -failfast -coverprofile cover.out
 
+# Build Go warmup library for JavaScript runtime compatibility
+echo "Building Go warmup library for Linux x64..."
+CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -buildmode=c-shared -ldflags='-s -w' -o output/go-warmup-linux-x64.so -tags="" go_warmup.go
+rm -f output/go_warmup.h  # Remove unnecessary header file
+
 find output/ -print0 | xargs -0 file
 


### PR DESCRIPTION
- Add go_warmup.go with minimal Warmup() export function
- Update build scripts to generate platform-specific warmup libraries
- Include warmup libraries in GitHub release artifacts
- Add documentation explaining purpose and usage

This enables JavaScript runtimes (like Bun) to initialize the Go runtime via FFI before loading CGO-based N-API modules, preventing crashes during crypto/x509 initialization.