### PR TITLE
Add debug testing options and bug fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/godaddy/asherah/go/appencryption v0.9.0
 	github.com/godaddy/asherah/go/securememory v0.1.7
-	github.com/godaddy/cobhan-go v0.4.3
+	github.com/godaddy/cobhan-go v0.5.0
 	github.com/lib/pq v1.11.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/godaddy/asherah/go/appencryption v0.9.0 h1:8eKJ2hSGEzY3105pHCZV8wCL32
 github.com/godaddy/asherah/go/appencryption v0.9.0/go.mod h1:x21eDOL6i8Ea9ynNIungAujq5TFTXiNs1Y3xmvL3xB4=
 github.com/godaddy/asherah/go/securememory v0.1.7 h1:U8baVJeOxuBjCzu7QnQkvcHbA9FfiZ1F1+WJSUca1/U=
 github.com/godaddy/asherah/go/securememory v0.1.7/go.mod h1:3AF+7BGAWflig7rp0zdkdi+hfi1616UFtOxBdWiMP9g=
-github.com/godaddy/cobhan-go v0.4.3 h1:pIkkJ1fr8AA56WR9pUy6Pu2KOVCzgllwS/BX4ucqFJY=
-github.com/godaddy/cobhan-go v0.4.3/go.mod h1:07aRS3E5apQ9gmpSn2e/BmniBDk8AU67QtmQda8uoNI=
+github.com/godaddy/cobhan-go v0.5.0 h1:14fkjTq+j8RFlCLiDOqvoY6l/wCuxL9c0Akd62yNYcM=
+github.com/godaddy/cobhan-go v0.5.0/go.mod h1:07aRS3E5apQ9gmpSn2e/BmniBDk8AU67QtmQda8uoNI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/libasherah.go
+++ b/libasherah.go
@@ -20,7 +20,6 @@ import (
 )
 
 var EstimatedIntermediateKeyOverhead = 0
-var disableZeroCopy atomic.Bool
 var nullDataCheck atomic.Bool
 
 func main() {
@@ -98,7 +97,7 @@ func SetupJson(configJson unsafe.Pointer) (result int32) {
 	log.DebugLog("Successfully deserialized config JSON")
 
 	EstimatedIntermediateKeyOverhead = len(options.ProductID) + len(options.ServiceName)
-	disableZeroCopy.Store(options.DisableZeroCopy)
+	cobhan.CopyBuffers(options.DisableZeroCopy)
 	nullDataCheck.Store(options.NullDataCheck)
 
 	err := asherah.Setup(options)
@@ -195,6 +194,12 @@ func Encrypt(partitionIdPtr unsafe.Pointer, dataPtr unsafe.Pointer, outputEncryp
 		}
 	}()
 
+	inputAlreadyNull := false
+	if nullDataCheck.Load() && cobhan.IsBufferAllNulls(dataPtr) {
+		log.ErrorLogf("Encrypt: input data buffer is all null before encryption (len=%d)", cobhan.BufferLength(dataPtr))
+		inputAlreadyNull = true
+	}
+
 	var drr *appencryption.DataRowRecord
 	var err error
 	drr, result, err = encryptData(partitionIdPtr, dataPtr)
@@ -202,6 +207,10 @@ func Encrypt(partitionIdPtr unsafe.Pointer, dataPtr unsafe.Pointer, outputEncryp
 		log.ErrorLogf("Failed to encrypt data %v", cobhan.CobhanErrorToString(result))
 		log.ErrorLogf("Encrypt failed: encryptData returned %v", err)
 		return result
+	}
+
+	if !inputAlreadyNull && nullDataCheck.Load() && cobhan.IsBufferAllNulls(dataPtr) {
+		log.ErrorLogf("Encrypt: input data buffer was nulled during encryption (len=%d)", cobhan.BufferLength(dataPtr))
 	}
 
 	result = cobhan.BytesToBuffer(drr.Data, outputEncryptedDataPtr)
@@ -247,6 +256,12 @@ func EncryptToJson(partitionIdPtr unsafe.Pointer, dataPtr unsafe.Pointer, jsonPt
 		}
 	}()
 
+	inputAlreadyNull := false
+	if nullDataCheck.Load() && cobhan.IsBufferAllNulls(dataPtr) {
+		log.ErrorLogf("EncryptToJson: input data buffer is all null before encryption (len=%d)", cobhan.BufferLength(dataPtr))
+		inputAlreadyNull = true
+	}
+
 	var drr *appencryption.DataRowRecord
 	var err error
 	drr, result, err = encryptData(partitionIdPtr, dataPtr)
@@ -254,6 +269,10 @@ func EncryptToJson(partitionIdPtr unsafe.Pointer, dataPtr unsafe.Pointer, jsonPt
 		log.ErrorLogf("Failed to encrypt data %v", cobhan.CobhanErrorToString(result))
 		log.ErrorLogf("EncryptToJson failed: encryptData returned %v", err)
 		return result
+	}
+
+	if !inputAlreadyNull && nullDataCheck.Load() && cobhan.IsBufferAllNulls(dataPtr) {
+		log.ErrorLogf("EncryptToJson: input data buffer was nulled during encryption (len=%d)", cobhan.BufferLength(dataPtr))
 	}
 
 	result = cobhan.JsonToBuffer(drr, jsonPtr)
@@ -323,21 +342,7 @@ func encryptData(partitionIdPtr unsafe.Pointer, dataPtr unsafe.Pointer) (*appenc
 		return nil, result, errors.New(errorMessage)
 	}
 
-	if disableZeroCopy.Load() {
-		dataCopy := make([]byte, len(data))
-		copy(dataCopy, data)
-		data = dataCopy
-	}
-
-	if nullDataCheck.Load() && isBufferAllNull(data) {
-		log.ErrorLogf("encryptData: input data buffer is all null before encryption (len=%d)", len(data))
-	}
-
 	drr, err := asherah.Encrypt(partitionId, data)
-
-	if nullDataCheck.Load() && isBufferAllNull(data) {
-		log.ErrorLogf("encryptData: input data buffer was nulled during encryption (len=%d)", len(data))
-	}
 
 	if err != nil {
 		if err == asherah.ErrAsherahNotInitialized {
@@ -347,19 +352,6 @@ func encryptData(partitionIdPtr unsafe.Pointer, dataPtr unsafe.Pointer) (*appenc
 	}
 
 	return drr, cobhan.ERR_NONE, nil
-}
-
-func isBufferAllNull(data []byte) bool {
-	checkLen := 64
-	if len(data) < checkLen {
-		checkLen = len(data)
-	}
-	for i := 0; i < checkLen; i++ {
-		if data[i] != 0 {
-			return false
-		}
-	}
-	return true
 }
 
 func decryptData(partitionIdPtr unsafe.Pointer, drr *appencryption.DataRowRecord) ([]byte, int32, error) {

--- a/libasherah_test.go
+++ b/libasherah_test.go
@@ -308,10 +308,6 @@ func TestEncryptDecryptRoundTripWithDefensiveCopy(t *testing.T) {
 	}
 	defer Shutdown()
 
-	if !disableZeroCopy.Load() {
-		t.Error("DisableZeroCopy was not set by SetupJson")
-	}
-
 	input := "InputData"
 	partitionId := testAllocateStringBuffer(t, "Partition")
 	data := testAllocateStringBuffer(t, input)


### PR DESCRIPTION
## Summary
- **Bug fixes**: Fix race condition in `Setup()` using `CompareAndSwap`, fix panic-on-panic in exported functions (return `ERR_PANIC` instead), fix `SetEnv` error handling, fix `EstimateBuffer` base64 calculation, close DB connection on `Shutdown()`, add missing error log in `Decrypt`
- **Debug features**: Add `DisableZeroCopy` option to defensively copy FFI input buffers, add `NullDataCheck` option to detect all-null input data before/after encryption
- **cobhan-go v0.5.0**: Use `cobhan.CopyBuffers()` for zero-copy control and `cobhan.IsBufferAllNulls()`/`cobhan.BufferLength()` for null data checks at the FFI edge

## Test plan
- [x] All existing tests pass
- [x] `TestEncryptDecryptRoundTripWithDefensiveCopy` validates the defensive copy path
- [ ] Manual testing with `NullDataCheck` enabled to verify logging behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)