### PR TITLE
fix: bump Go toolchain to 1.24.13 for CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/godaddy/asherah-cobhan
 
 go 1.24.0
 
-toolchain go1.24.1
+toolchain go1.24.13
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8


### PR DESCRIPTION
## Summary

Bumps the Go toolchain directive from `go1.24.1` to `go1.24.13` to fix CVE-2025-68121 (Go stdlib vulnerability).

## Motivation

Qualys container scanning has flagged the precompiled npm `asherah` binaries with:

| CVE | Package | Current | Required |
|-----|---------|---------|----------|
| CVE-2025-68121 | Go stdlib | v1.20.12 (in published npm binary) | >= 1.24.13 |
| CVE-2024-45337 | golang.org/x/crypto | v0.27.0 (in published npm binary) | >= v0.31.0 |

The source already has `golang.org/x/crypto v0.45.0` which fixes CVE-2024-45337. However, the `toolchain go1.24.1` does not fix CVE-2025-68121 — that requires Go >= 1.24.13.

## Changes

- `go.mod`: Changed `toolchain go1.24.1` → `toolchain go1.24.13`

## After Merge

Once merged and a new release is cut, the `publish.yml` workflow will build the native binaries with Go 1.24.13, resolving both CVEs in the distributed artifacts. Downstream npm consumers can then upgrade to pick up the fix.

Ref: #87